### PR TITLE
[PRODU-546] restructure log content

### DIFF
--- a/dv_utils/__init__.py
+++ b/dv_utils/__init__.py
@@ -9,4 +9,4 @@ from .process import process_event_dummy
 from .redis import RedisQueue
 from .settings import Settings
 from .settings import settings as default_settings
-from .log_utils import audit_log, audit_log_async, set_event, LogLevel
+from .log_utils import log, set_event, LogLevel

--- a/dv_utils/connectors/azure.py
+++ b/dv_utils/connectors/azure.py
@@ -1,11 +1,9 @@
 import logging
 import copy
 import json
-import duckdb
 
 from dv_utils.connectors.connector import Configuration
 from ..secret_manager import SecretManager
-from ..log_utils import audit_log, LogLevel
 
 logger = logging.getLogger(__name__)
 

--- a/dv_utils/connectors/file.py
+++ b/dv_utils/connectors/file.py
@@ -7,7 +7,7 @@ import os
 import json
 import copy
 import cloudscraper
-from ..log_utils import audit_log, LogLevel
+from ..log_utils import log, LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class FileConnector():
         file_names = self.config.file_name.split(',')
 
         if len(urls) != len(file_names):
-            audit_log(f'Length of urls and file list should be the same. Got {len(urls)} and {len(file_names)}', level=LogLevel.ERROR)
+            log(f'Length of urls and file list should be the same. Got {len(urls)} and {len(file_names)}', level=LogLevel.ERROR)
             return
         
         for i in range(len(urls)):
@@ -63,12 +63,12 @@ class FileConnector():
             with open(os.path.join(self.config.download_directory, file_name), 'w') as file:
                 file.write(response.text)
         else:
-            audit_log(f'Could not download file {file_name} from {url}. Got {response.status_code}', level=LogLevel.ERROR)
-        audit_log(f'Downloaded {file_name}')
+            log(f'Could not download file {file_name} from {url}. Got {response.status_code}', level=LogLevel.ERROR)
+        log(f'Downloaded {file_name}')
     
     def __handle_response(self, response) -> bool :
         if(response.status_code > 399):
-            audit_log(f"Response returned status code [{response.status_code}]", level=LogLevel.WARN)
+            log(f"Response returned status code [{response.status_code}]", level=LogLevel.WARN)
             return False
         
         return True

--- a/dv_utils/connectors/gcs.py
+++ b/dv_utils/connectors/gcs.py
@@ -1,11 +1,10 @@
 import logging
 import copy
 import json
-import duckdb
 
 from dv_utils.connectors.connector import Configuration
 from ..secret_manager import SecretManager
-from ..log_utils import audit_log, LogLevel
+
 
 logger = logging.getLogger(__name__)
 

--- a/dv_utils/connectors/s3.py
+++ b/dv_utils/connectors/s3.py
@@ -1,11 +1,9 @@
 import logging
 import copy
 import json
-import duckdb
 
 from dv_utils.connectors.connector import Configuration
 from ..secret_manager import SecretManager
-from ..log_utils import audit_log, LogLevel
 
 logger = logging.getLogger(__name__)
 

--- a/dv_utils/connectors/solid.py
+++ b/dv_utils/connectors/solid.py
@@ -2,7 +2,6 @@ import copy
 
 from dv_utils import solid_utils
 from dv_utils.connectors.connector import Configuration
-from ..log_utils import audit_log, LogLevel
 
 class SolidConfiguration(Configuration):
   schema_file = "solid.json"

--- a/dv_utils/datasets/contract.py
+++ b/dv_utils/datasets/contract.py
@@ -15,7 +15,7 @@ from ..settings import settings as default_settings
 from ..connectors.connector import populate_configuration
 from ..connectors import s3,gcs,azure,file
 
-from ..log_utils import audit_log, LogLevel
+from ..log_utils import log, LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -91,11 +91,11 @@ class Contract:
                     scan_result = scan.get_scan_results()
                     if(scan_result['hasErrors'] or scan_result['hasFailures']):
                         string_to_log=f'Quality check done data descriptor {self.data_descriptor_id}. Scan result NOK'
-                        audit_log(string_to_log,LogLevel.WARN)
+                        log(string_to_log,LogLevel.WARN)
                         logging.error(string_to_log)
                     else:
                         string_to_log=f'Quality check done data descriptor {self.data_descriptor_id}. Scan result OK'
-                        audit_log(string_to_log)
+                        log(string_to_log)
                         logging.debug(string_to_log)
                     scan_results[soda_check]=scan_result
                 #return results in json to the caller for further user (show to end user, ...)

--- a/dv_utils/datasets/contract_manager.py
+++ b/dv_utils/datasets/contract_manager.py
@@ -6,7 +6,7 @@ import yaml
 
 from ..settings import Settings
 from ..settings import settings as default_settings
-from ..log_utils import audit_log, LogLevel
+from ..log_utils import log, LogLevel
 from ..client import Client
 from .contract import Contract
 
@@ -49,22 +49,22 @@ class ContractManager:
             return None 
 
     def check_contract_for_data_descriptor(self, data_descriptor_id: str, data_descriptor:str):
-        audit_log(f"Check data contract for data_descriptor: {data_descriptor['id']}")
+        log(f"Check data contract for data_descriptor: {data_descriptor['id']}")
         contract=self.get_contract_for_data_descriptor(data_descriptor_id,data_descriptor)
         return contract.check_contract()
     
     def check_contracts_for_collaboration_space(self, collaboration_space_id: str):
-        audit_log(f"Check data contract for collaboration space {collaboration_space_id}")
+        log(f"Check data contract for collaboration space {collaboration_space_id}")
         scan_results={}
         data_contracts=self.get_contracts_for_collaboration_space(collaboration_space_id)
         if data_contracts != None and len(data_contracts)>0:
             for data_contract in data_contracts:
                 data_descriptor_id=data_contract.data_descriptor_id
-                audit_log(f"Check data contract for data descriptor: {data_descriptor_id}")
+                log(f"Check data contract for data descriptor: {data_descriptor_id}")
                 scan_results[data_descriptor_id]=data_contract.check_contract()
         else:
             logger.error(f"No data contract available for collaboration_space_id: {collaboration_space_id}")
-            audit_log(f"Error verifying data contracts for collaboration space {collaboration_space_id}. No data contract available.",LogLevel.ERROR)
+            log(f"Error verifying data contracts for collaboration space {collaboration_space_id}. No data contract available.",LogLevel.ERROR)
             raise Exception(f"Unable to check data contracts for collaboration space {collaboration_space_id}")
         return scan_results
     

--- a/dv_utils/listener.py
+++ b/dv_utils/listener.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 from .process import process_event_dummy
 from .redis import RedisQueue
-from .log_utils import audit_log, set_event
+from .log_utils import log, set_event
 import time
 
 class DefaultListener:
@@ -22,7 +22,7 @@ class DefaultListener:
         redis_queue.create_consumer_group()
 
         if(daemon):
-           audit_log(log="Algo Event Listener started", app="algo")
+           log(log="Algo Event Listener started", app="algo")
 
         while True:
            evt = redis_queue.listen_once()
@@ -31,16 +31,16 @@ class DefaultListener:
                evt_type =evt.get("type", "MISSING_TYPE")
                set_event(evt)
                if(log_events):
-                  audit_log("Event processing started", state="STARTED", app="algo")
+                  log("Event processing started", state="STARTED", app="algo")
 
                try:
                   event_processor(evt)
                except Exception as err:
                   if(log_events):
-                     audit_log("Event processing failed",  state="FAILED", app="algo", error=str(err), processing_time=time.time()-start)
+                     log("Event processing failed",  state="FAILED", app="algo", error=str(err), processing_time=time.time()-start)
                else:
                   if(log_events):
-                     audit_log("Event processing done", evt=evt_type, state="DONE", app="algo", processing_time=time.time()-start)
+                     log("Event processing done", evt=evt_type, state="DONE", app="algo", processing_time=time.time()-start)
                
           
            if not daemon:
@@ -48,5 +48,5 @@ class DefaultListener:
                break
 
         if(daemon):
-           audit_log(log="Algo Event Listener Ended", app="algo")
+           log(log="Algo Event Listener Ended", app="algo")
 

--- a/dv_utils/listeners/priority.py
+++ b/dv_utils/listeners/priority.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 from ..process import process_event_dummy
 from ..redis import RedisQueue
-from ..log_utils import audit_log, set_event
+from ..log_utils import log, set_event
 import time
 
 class PriorityListener:
@@ -27,7 +27,7 @@ class PriorityListener:
 
     def __listen(self, daemon, log_events):
         if(daemon):
-           audit_log(log="Algo Event Listener started", app="algo")
+           log(log="Algo Event Listener started", app="algo")
 
         while True:
           evt, stream_name = self.__listen_once()
@@ -38,7 +38,7 @@ class PriorityListener:
             break
 
         if(daemon):
-           audit_log(log="Algo Event Listener Ended", app="algo")
+           log(log="Algo Event Listener Ended", app="algo")
 
     def __listen_once(self) -> tuple[str,str]:
       for stream_name in self.stream_priorities:
@@ -53,15 +53,15 @@ class PriorityListener:
       evt_type =evt.get("type", "MISSING_TYPE")
       set_event(evt, stream_name)
       if(log_events):
-        audit_log("Event processing started", state="STARTED", app="algo")
+        log("Event processing started", state="STARTED", app="algo")
 
       try:
         self.event_processor(evt)
       except Exception as err:
         if(log_events):
-          audit_log("Event processing failed", evt=evt_type, state="FAILED", app="algo", error=str(err), processing_time=time.time()-start)
+          log("Event processing failed", evt=evt_type, state="FAILED", app="algo", error=str(err), processing_time=time.time()-start)
       else:
         if(log_events):
-          audit_log("Event processing done", evt=evt_type, state="DONE", app="algo", processing_time=time.time()-start)
+          log("Event processing done", evt=evt_type, state="DONE", app="algo", processing_time=time.time()-start)
       
 

--- a/dv_utils/log_utils.py
+++ b/dv_utils/log_utils.py
@@ -40,9 +40,6 @@ class LogMetadata:
 
 _metadata = LogMetadata()
 
-def get_loki_url() -> str:
-    return default_settings.config("DV_LOKI", "http://loki.datavillage.svc.cluster.local:3100")
-
 def get_app_namespace() -> str | None:
     cage_id = default_settings.config('DV_CAGE_ID', None)
     if not cage_id:
@@ -66,26 +63,10 @@ def create_body(log: str, level: LogLevel, **kwargs):
 
     return log_dict
 
-# TODO: should we also add an optional parameter `start_ns` to automatically add `duration_ns` (or whatever) field?
-def audit_log(log:str, level:LogLevel = LogLevel.INFO, **kwargs):
+def log(log:str, level:LogLevel = LogLevel.INFO, **kwargs):
     if log is None:
         return
     #add timestamp in the log
     data = create_body(log, level, **kwargs)
     json_encoded = json.dumps(data)
     print(json_encoded, file=sys.stderr)
-
-
-
-# TODO: deprecate or delete
-async def audit_log_async(log:str|dict|None=None, level: LogLevel = LogLevel.INFO):
-    loki_url = get_loki_url()
-    if (loki_url == 'STDOUT' or loki_url == 'STDERR'):
-        audit_log(log, level)
-    else:
-        app_namespace = get_app_namespace()
-        body = create_body(log, level)
-        async with httpx.AsyncClient() as client:
-            r = await client.post(url=f'{get_loki_url()}/loki/api/v1/push', json=body, headers={"X-Scope-OrgID": app_namespace, "Content-Type": "application/json"})
-            if(r.status_code!=204):
-                print(f"Error pushing log {r}", flush=True)

--- a/dv_utils/log_utils.py
+++ b/dv_utils/log_utils.py
@@ -29,7 +29,7 @@ class LogMetadata:
         self.app_id = default_settings.config("DV_APP_ID", None)
         self.lib_version = version('dv-utils')
 
-    def set_event(self, evt: dict, evt_stream: str, evt_received_ns: int | None = None):
+    def set_event(self, evt: str, evt_stream: str, evt_received_ns: int | None = None):
         self.evt = evt
         self.evt_stream = evt_stream
         self.evt_received = evt_received_ns if evt_received_ns is not None else time.time_ns()
@@ -51,7 +51,7 @@ def get_app_namespace() -> str | None:
         return f'app-{cage_id}'
 
 def set_event(evt: dict, stream: str = "events", evt_received_ns: int | None = None):
-    _metadata.set_event(evt, stream, evt_received_ns)
+    _metadata.set_event(evt['type'], stream, evt_received_ns)
 
 def create_body(log: str, level: LogLevel, **kwargs):
     log_dict = dict()

--- a/dv_utils/log_utils.py
+++ b/dv_utils/log_utils.py
@@ -26,7 +26,7 @@ class LogMetadata:
         self.evt = None
         self.evt_received = None
         self.evt_stream = None
-        self.app_id = default_settings.config("DV_APP_ID", None)
+        self.cage_id = default_settings.config("DV_CAGE_ID", None)
         self.lib_version = version('dv-utils')
 
     def set_event(self, evt: str, evt_stream: str, evt_received_ns: int | None = None):

--- a/dv_utils/log_utils.py
+++ b/dv_utils/log_utils.py
@@ -67,7 +67,7 @@ def create_body(log: str, level: LogLevel, **kwargs):
     return log_dict
 
 # TODO: should we also add an optional parameter `start_ns` to automatically add `duration_ns` (or whatever) field?
-def audit_log(log:str, level:LogLevel = LogLevel.AUDIT, **kwargs):
+def audit_log(log:str, level:LogLevel = LogLevel.INFO, **kwargs):
     if log is None:
         return
     #add timestamp in the log

--- a/dv_utils/solid_utils.py
+++ b/dv_utils/solid_utils.py
@@ -2,7 +2,7 @@ import requests
 import json
 import base64
 from os import environ
-from dv_utils import audit_log, LogLevel
+from dv_utils import log, LogLevel
 
 """
 Fetches a resource from a pod using acp protocol and return as string
@@ -17,7 +17,7 @@ def get_acp_from_pod_url(pod_url: str, path: str, solid_oidp_token: str = None, 
 
   res = requests.get(resource_uri, headers={'Authorization': f"Bearer {uma_token}"})
   if not res.ok:
-    audit_log(f"Could not get file with uma token. Got [{res.status_code}]: {res.text}")
+    log(f"Could not get file with uma token. Got [{res.status_code}]: {res.text}")
     return None
   
   return res.text
@@ -33,7 +33,7 @@ def __get_dv_soidp_token() -> str:
 
   res = requests.get(token_endpoint, params=query_params, auth=(user_name, password))
   if not res.ok:
-    audit_log(f"Could not get token from solid idp. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
+    log(f"Could not get token from solid idp. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
 
   return res.json()['token']
 
@@ -65,7 +65,7 @@ def get_uma_token(solid_idp_token: str, resource_uri: str, access_grant: dict | 
     access_grant = find_access_grant(solid_idp_token, resource_uri, vc_configuration['derivationService'], verify_grant)
 
   elif verify_grant and not verify_verifiable_credential(access_grant, vc_configuration['verifierService']):
-    audit_log(f"access grant not valid {access_grant['id']}", LogLevel.ERROR)
+    log(f"access grant not valid {access_grant['id']}", LogLevel.ERROR)
     return None
 
   # Call 3: get uma token without scopes
@@ -82,7 +82,7 @@ def get_permission_ticket(resource_uri: str) -> tuple[str, str]:
   res = requests.get(resource_uri)
 
   if res.status_code != 401:
-    audit_log(f"Expected status code 401, got {res.status_code}", LogLevel.ERROR)
+    log(f"Expected status code 401, got {res.status_code}", LogLevel.ERROR)
     return {}
   
   # UMA as_uri="https://uma...", ticket="ey...",...
@@ -110,7 +110,7 @@ Fetches all access requests for a Solid OIDP token from the vc and finds the fir
 def find_access_grant(solid_idp_token: str, resource_uri: str, vc_derive_endpoint: str, verify_grants: bool = False) -> dict:
   filtered_access_grants = [r for r in get_all_access_grants(vc_derive_endpoint, solid_idp_token) if __is_access_grant_for_resource(resource_uri, r, verify_grants)]
   if not len(filtered_access_grants):
-    audit_log(f"Could not find access request for resource {resource_uri}", LogLevel.ERROR)
+    log(f"Could not find access request for resource {resource_uri}", LogLevel.ERROR)
     return None
   
   return filtered_access_grants[0]
@@ -133,7 +133,7 @@ def get_all_access_grants(vc_derive_endpoint: str, solid_id_token: str, verify_g
 
   res = requests.post(vc_derive_endpoint, json=body, headers=headers)
   if not res.ok:
-    audit_log(f"Could not get all access grants. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
+    log(f"Could not get all access grants. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
     return None
 
   res_json = res.json()
@@ -170,7 +170,7 @@ def verify_verifiable_credential(verifiable_credential: dict, vc_verify_endpoint
 
   verify_response = requests.post(vc_verify_endpoint, json=verify_body, headers={'Content-Type': 'application/json'})
   if not verify_response.ok:
-    audit_log(f"could not verify verifiable credential. Got [{verify_response.status_code}]: {verify_response.text}", LogLevel.ERROR)
+    log(f"could not verify verifiable credential. Got [{verify_response.status_code}]: {verify_response.text}", LogLevel.ERROR)
     return False
 
   response_json = verify_response.json()
@@ -202,7 +202,7 @@ def __request_uma_unscoped_token(access_grant_body: dict, uma_token_endpoint:str
   res = requests.post(uma_token_endpoint, payload, headers=headers)
   
   if not res.ok:
-    audit_log(f"Could not get unscoped uma token. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
+    log(f"Could not get unscoped uma token. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
     return ""
   
   res_json = res.json()
@@ -225,7 +225,7 @@ def __request_uma_scoped_token(uma_token_endpoint: str, permission_ticket: str, 
   res = requests.post(uma_token_endpoint, payload, headers=headers)
 
   if not res.ok:
-    audit_log(f"Could not get scoped uma token. Got [{res.status_code}]: {res.text}")
+    log(f"Could not get scoped uma token. Got [{res.status_code}]: {res.text}")
     return ""
   
   res_json = res.json()
@@ -254,7 +254,7 @@ def get_access_grant_for_resource(vc_derive_endpoint: str, solid_id_token: str, 
   res = requests.post(vc_derive_endpoint, json=body, headers=headers)
 
   if not res.ok:
-    audit_log(f"Could not search grants at VC. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
+    log(f"Could not search grants at VC. Got [{res.status_code}]: {res.text}", LogLevel.ERROR)
     return []
   
   return res.json()['verifiableCredential']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "dv-utils"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 description = "Datavillage python utils for building algorithm running in confidential environment"
 authors = ["Datavillage Technical Team <developer@datavillage.ai>"]
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dv-utils
-version = 2.0.0rc3
+version = 2.0.0rc4
 
 [options]
 packages = find:


### PR DESCRIPTION
[PRODU-546](https://app.plane.so/datavillage/projects/326ee63f-7e0a-47c2-b83b-af85023dd846/issues/a68f68fe-968a-4b9c-8201-50526da2c139)
log example:

```
{"msg": "event_processor started", "evt": "EX_READ_SPACE", "evt_received": 1738915783401202000, "evt_stream": "events", "cage_id": "fwuotfux", "lib_version": "2.0.0rc4", "level": "INFO", "timestamp": 1738915783401224000}
{"msg": "A testing space\nData Providers\n  678681a9c97d608651cd8fe8\n\nCode Provider\n  My Code Provider\n\nData Consumers\n  678681a9c97d608651cd8fe8\n", "evt": "EX_READ_SPACE", "evt_received": 1738915783401202000, "evt_stream": "events", "cage_id": "fwuotfux", "lib_version": "2.0.0rc4", "level": "INFO", "timestamp": 1738915783842735000}
{"msg": "done processing event", "evt": "EX_READ_SPACE", "evt_received": 1738915783401202000, "evt_stream": "events", "cage_id": "fwuotfux", "lib_version": "2.0.0rc4", "level": "INFO", "timestamp": 1738915783843091000}
```

If we want it to integrate more with Python logging module, we could:
- create a [record factory](https://docs.python.org/3/library/logging.html#logrecord-objects)
  - add metadata we need to the records
- create a small [handler](https://docs.python.org/3/library/logging.html#formatter-objects) that writes as json
  - like [here](https://stackoverflow.com/questions/50144628/python-logging-into-file-as-a-dictionary-or-json), but smaller 
- replace the `print` call in the `log` method with calls to logger factory with correct configuration

This would give us all python logging features 'for free' with little code from the algo developer. Will take some time so might be a later version than `2.0.0`. We could probably just give them a [logging.conf](https://docs.python.org/2/howto/logging.html#configuring-logging) file and have everything set up correctly.